### PR TITLE
Eliminate need for nested blocks

### DIFF
--- a/lib/docker/api/base.rb
+++ b/lib/docker/api/base.rb
@@ -46,7 +46,7 @@ class Docker::API::Base
     # @param &block: Replace the default output to stdout behavior.
     def default_reader path, url, header = {"Content-Type" => "application/x-tar"}, &block
         file = File.open(File.expand_path(path), "r")
-        response = @connection.request(method: :post, path: url , headers: header, request_block: lambda { file.read(Excon.defaults[:chunk_size]).to_s}, response_block: block_given? ? block.call : default_streamer )
+        response = @connection.request(method: :post, path: url , headers: header, request_block: lambda { file.read(Excon.defaults[:chunk_size]).to_s}, response_block: block_given? ? block : default_streamer )
         file.close
         response
     end

--- a/lib/docker/api/container.rb
+++ b/lib/docker/api/container.rb
@@ -204,7 +204,7 @@ class Docker::API::Container < Docker::API::Base
         path = build_path("/containers/#{name}/logs", params)
 
         if [true, 1 ].include? params[:follow]
-            @connection.request(method: :get, path: path , response_block: block_given? ? block.call : default_streamer)
+            @connection.request(method: :get, path: path , response_block: block_given? ? block : default_streamer)
         else
             @connection.get(path)
         end
@@ -220,7 +220,7 @@ class Docker::API::Container < Docker::API::Base
     # @param params [Hash]: Parameters that are appended to the URL.
     # @param &block: Replace the default output to stdout behavior.
     def attach name, params = {}, &block
-        @connection.request(method: :post, path: build_path("/containers/#{name}/attach", params) , response_block: block_given? ? block.call : default_streamer)
+        @connection.request(method: :post, path: build_path("/containers/#{name}/attach", params) , response_block: block_given? ? block : default_streamer)
     end
 
     ##
@@ -247,7 +247,7 @@ class Docker::API::Container < Docker::API::Base
     def stats name, params = {}, &block
         path = build_path("/containers/#{name}/stats", params)
         if [true, 1 ].include? params[:stream]
-            @connection.request(method: :get, path: path , response_block: block_given? ? block.call : default_streamer)
+            @connection.request(method: :get, path: path , response_block: block_given? ? block : default_streamer)
         else
             @connection.get(path)
         end
@@ -265,7 +265,7 @@ class Docker::API::Container < Docker::API::Base
     def export name, path, &block
         response = self.details(name)
         return response unless response.status == 200
-        @connection.request(method: :get, path: "/containers/#{name}/export" , response_block: block_given? ? block.call : default_writer(path))
+        @connection.request(method: :get, path: "/containers/#{name}/export" , response_block: block_given? ? block : default_writer(path))
     end
 
     ##
@@ -285,7 +285,7 @@ class Docker::API::Container < Docker::API::Base
         return response unless response.status == 200 
         
         file = File.open( File.expand_path( path ) , "wb")
-        response = @connection.request(method: :get, path: build_path("/containers/#{name}/archive", params) , response_block: block_given? ? block.call : lambda { |chunk, remaining_bytes, total_bytes| file.write(chunk) })
+        response = @connection.request(method: :get, path: build_path("/containers/#{name}/archive", params) , response_block: block_given? ? block : lambda { |chunk, remaining_bytes, total_bytes| file.write(chunk) })
         file.close
         response
     end

--- a/lib/docker/api/exec.rb
+++ b/lib/docker/api/exec.rb
@@ -26,7 +26,7 @@ class Docker::API::Exec < Docker::API::Base
     # @param &block: Replace the default output to stdout behavior.
     def start name, body = {}, &block
         @connection.request(method: :post, path: "/exec/#{name}/start", headers: {"Content-Type": "application/json"},  body: body.to_json, 
-            response_block: block_given? ? block.call : default_streamer )
+            response_block: block_given? ? block : default_streamer )
     end
 
     ##

--- a/lib/docker/api/image.rb
+++ b/lib/docker/api/image.rb
@@ -105,7 +105,7 @@ class Docker::API::Image < Docker::API::Base
     # @param path [String]: Path to the exported file.
     # @param &block: Replace the default file writing behavior.
     def export name, path, &block
-        @connection.request(method: :get, path: build_path("/images/#{name}/get") , response_block: block_given? ? block.call : default_writer(path))
+        @connection.request(method: :get, path: build_path("/images/#{name}/get") , response_block: block_given? ? block : default_writer(path))
     end
 
     ##
@@ -158,7 +158,7 @@ class Docker::API::Image < Docker::API::Base
     # @param authentication [Hash]: Authentication parameters.
     # @param &block: Replace the default output to stdout behavior.
     def create params = {}, authentication = {}, &block
-        request = {method: :post, path: build_path("/images/create", params), response_block: block_given? ? block.call : default_streamer }
+        request = {method: :post, path: build_path("/images/create", params), response_block: block_given? ? block : default_streamer }
         if params.has_key? :fromSrc and !params[:fromSrc].match(/^(http|https)/) # then it's using a tar file
             path = params[:fromSrc]
             params[:fromSrc] = "-"
@@ -186,7 +186,7 @@ class Docker::API::Image < Docker::API::Base
         headers.merge!({"X-Registry-Config": auth_encoder(authentication) }) if authentication.keys.size > 0
 
         if path == nil and params.has_key? :remote
-            response = @connection.request(method: :post, path: build_path("/build", params), headers: headers, response_block: block_given? ? block.call : default_streamer)
+            response = @connection.request(method: :post, path: build_path("/build", params), headers: headers, response_block: block_given? ? block : default_streamer)
         else
             default_reader(path, build_path("/build", params), headers)
         end

--- a/lib/docker/api/system.rb
+++ b/lib/docker/api/system.rb
@@ -23,7 +23,7 @@ class Docker::API::System < Docker::API::Base
     # @param params [Hash]: Parameters that are appended to the URL.
     # @param &block: Replace the default output to stdout behavior.
     def events params = {}, &block
-        @connection.request(method: :get, path: build_path("/events", params), response_block: block_given? ? block.call : default_streamer )
+        @connection.request(method: :get, path: build_path("/events", params), response_block: block_given? ? block : default_streamer )
     end
 
     ##

--- a/lib/docker/api/task.rb
+++ b/lib/docker/api/task.rb
@@ -36,7 +36,7 @@ class Docker::API::Task < Docker::API::Base
         path = build_path("/tasks/#{name}/logs", params)
 
         if [true, 1 ].include? params[:follow]
-            @connection.request(method: :get, path: path , response_block: block_given? ? block.call : default_streamer)
+            @connection.request(method: :get, path: path , response_block: block_given? ? block : default_streamer)
         else
             @connection.get(path)
         end


### PR DESCRIPTION
For methods that allow a custom block, this PR causes those blocks to be passed directly through to excon. This eliminates the need to nest a lambda inside the block and simplifies the overall usage of those methods.

old usage:
```
Docker::API::Image.new.create(...) do
  lambda do |ch,rb,tb|
    # do something
  end
end
```

new usage:
```
Docker::API::Image.new.create(...) do |ch,tb,tb|
  # do something
end
```
