### PR TITLE
Relax excon version

### DIFF
--- a/dockerapi.gemspec
+++ b/dockerapi.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("excon", "~> 0.76.0")
+  spec.add_dependency("excon", "~> 0.76")
 end


### PR DESCRIPTION
This just relaxes the `excon` version a little bit to allow `excon` to be upgraded within the 0.x series.
