### PR TITLE
Add authentication arg to Image#distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ image.details("image")
 
 # Return image digest and platform information by contacting the registry.
 image.distribution("image")
+image.distribution("image", {username: "janedoe", password: "password"}) # private repository
 
 # History
 image.history("image")
@@ -94,7 +95,7 @@ image.tag("current:tag", repo: "new", tag: "tag")
 # Push image
 image.push("repo:tag") # to dockerhub
 image.push("localhost:5000/repo:tag") # to local registry
-image.push("private/repo", {tag: "tag"}, {username: "janedoe", password: "password"} # to private repository
+image.push("private/repo", {tag: "tag"}, {username: "janedoe", password: "password"}) # to private repository
 
 # Remove image
 image.remove("image")

--- a/lib/docker/api/image.rb
+++ b/lib/docker/api/image.rb
@@ -21,8 +21,11 @@ class Docker::API::Image < Docker::API::Base
     # @see https://docs.docker.com/engine/api/v1.40/#tag/Distribution
     #
     # @param name [String]: The ID or name of the image.
-    def distribution name
-        @connection.get("/distribution/#{name}/json")
+    # @param authentication [Hash]: Authentication parameters.
+    def distribution name, authentication = {}
+        request = {method: :get, path: "/distribution/#{name}/json"}
+        request[:headers] = {"X-Registry-Auth" => auth_encoder(authentication)} if authentication.any?
+        @connection.request(request)
     end
 
     ##


### PR DESCRIPTION
This PR adds an authentication arg to `image.distribution`, much like already exists for `image.build` and `image.create`.
