### PR TITLE
Allow excon 1.x and require base64 for modern rubies

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
         printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
     - name: Install dependencies
       run: |
-        gem update --system 3.2.3
+        gem update --system 3.5.11
         bundle install
     - name: Release
       run: |

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in dockerapi.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,15 @@ PATH
   remote: .
   specs:
     dockerapi (0.20.0)
-      excon (~> 0.79)
+      base64
+      excon (>= 0.97, < 2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.2.0)
     diff-lcs (1.5.1)
-    excon (0.112.0)
+    excon (1.1.1)
     rake (12.3.3)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     base64 (0.2.0)
     diff-lcs (1.5.1)
     excon (1.1.1)
-    rake (12.3.3)
+    rake (13.2.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -32,7 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   dockerapi!
-  rake (~> 12.0)
+  rake (~> 13.0)
   rspec (~> 3.0)
 
 BUNDLED WITH

--- a/dockerapi.gemspec
+++ b/dockerapi.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("excon", "~> 0.79")
+  spec.add_dependency("base64")
+  spec.add_dependency("excon", ">= 0.97", "< 2")
 end

--- a/dockerapi.gemspec
+++ b/dockerapi.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Interact with Docker API directly from Ruby code. Comprehensive implementation (all available endpoints), no local Docker installation required, easily manipulated http responses."
   spec.homepage      = "https://github.com/nu12/dockerapi"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = ">= 3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/nu12/dockerapi.git"

--- a/dockerapi.gemspec
+++ b/dockerapi.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/nu12/dockerapi.git"
-  spec.metadata["changelog_uri"] = "https://github.com/nu12/dockerapi/blob/master/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "https://github.com/nu12/dockerapi/blob/main/CHANGELOG.md"
   spec.metadata["documentation_uri"] = "https://www.rubydoc.info/gems/dockerapi"
 
   # Specify which files should be added to the gem when it is released.

--- a/lib/docker/api/base.rb
+++ b/lib/docker/api/base.rb
@@ -18,7 +18,7 @@ class Docker::API::Base
     # Output to stdout.
     def default_streamer
         streamer = lambda do |chunk, remaining_bytes, total_bytes|
-            p chunk.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?') if Docker::API::PRINT_TO_STDOUT
+            p chunk.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?') if Docker::API.print_to_stdout
         end
         streamer
     end

--- a/lib/docker/api/connection.rb
+++ b/lib/docker/api/connection.rb
@@ -11,7 +11,7 @@ class Docker::API::Connection
     # @param params [Hash]: Request parameters.
     def request params
         response = Docker::API::Response.new(@connection.request(params).data)
-        p response if Docker::API::PRINT_RESPONSE_TO_STDOUT 
+        p response if Docker::API.print_response_to_stdout 
         response
     end
     

--- a/lib/dockerapi.rb
+++ b/lib/dockerapi.rb
@@ -27,11 +27,22 @@ module Docker
 
     ##
     # This variable controls output verbosity.
-    PRINT_TO_STDOUT = true
+    def self.print_to_stdout
+      @@print_to_stdout
+    end
+    def self.print_to_stdout=(bool)
+      @@print_to_stdout = bool
+    end
+    self.print_to_stdout = true
 
     ##
     # This variable controls output verbosity.
-    PRINT_RESPONSE_TO_STDOUT = false
+    def self.print_response_to_stdout
+      @@print_response_to_stdout
+    end
+    def self.print_response_to_stdout=(bool)
+      @@print_response_to_stdout = bool
+    end
 
     ##
     # Valid values for parameter validations.

--- a/lib/dockerapi.rb
+++ b/lib/dockerapi.rb
@@ -43,6 +43,7 @@ module Docker
     def self.print_response_to_stdout=(bool)
       @@print_response_to_stdout = bool
     end
+    self.print_response_to_stdout = false
 
     ##
     # Valid values for parameter validations.

--- a/spec/endpoints/image_spec.rb
+++ b/spec/endpoints/image_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Docker::API::Image do
 
             described_class.new.tag(original, repo: local)
 
-            Docker::API::PRINT_RESPONSE_TO_STDOUT = true
+            Docker::API.print_response_to_stdout = true
         end
 
         it { expect(Docker::API::Container.new.list.json.size).to be > 0 }
@@ -248,7 +248,7 @@ RSpec.describe Docker::API::Image do
         end
         
         after(:all) do
-            Docker::API::PRINT_RESPONSE_TO_STDOUT = false
+            Docker::API.print_response_to_stdout = false
 
             container = Docker::API::Container.new
             container.stop("registry")

--- a/spec/endpoints/image_spec.rb
+++ b/spec/endpoints/image_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Docker::API::Image do
             it { expect(subject.create(fromSrc: path, repo: image, message: "Imported with dockerapi").status).to eq(200) }
         end
         context "from remote tar file" do
-            let(:url) { "https://github.com/nu12/dockerapi/blob/master/resources/busybox.tar?raw=true" }
+            let(:url) { "https://github.com/nu12/dockerapi/raw/refs/heads/main/resources/busybox.tar" }
             it { expect(subject.create(fromSrc: url).status).to eq(200) }
             it { expect(subject.create(fromSrc: url, repo: image, message: "Imported with dockerapi").status).to eq(200) }
             it { expect(subject.create(fromSrc: "http://404").status).to eq(500) }
@@ -175,7 +175,7 @@ RSpec.describe Docker::API::Image do
         it { expect(subject.build("resources/build.tar.xz", memory: 4000000, rm: true, forcerm:true).status).to eq(200) }
         it { expect(subject.build("resources/build.tar.xz", memory: 4000000, rm: true, forcerm:true, pull:true).status).to eq(200) }
         it { expect(subject.build(nil, remote: "https://github.com/nu12/dockerapi/raw/refs/heads/main/resources/build.tar.xz").status).to eq(200) }
-        it { expect(subject.build(nil, remote: "https://raw.githubusercontent.com/nu12/dockerapi/master/resources/Dockerfile").status).to eq(200) }
+        it { expect(subject.build(nil, remote: "https://raw.githubusercontent.com/nu12/dockerapi/main/resources/Dockerfile").status).to eq(200) }
         it { expect{subject.build("resources/build.tar.xz", invalid: "invalid")}.to raise_error(Docker::API::InvalidParameter) }
         it { expect{subject.build(nil, remote: "https://github.com/nu12/dockerapi/raw/refs/heads/main/resources/build.tar.xz", invalid: "invalid")}.to raise_error(Docker::API::InvalidParameter) }
         it { expect{subject.build(nil, invalid: "invalid", skip_validation: true)}.to raise_error(Docker::API::Error) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 require "bundler/setup"
 require "dockerapi"
 
-Docker::API::PRINT_TO_STDOUT = false
+Docker::API.print_to_stdout = false
 
-Docker::API::PRINT_RESPONSE_TO_STDOUT = false
+Docker::API.print_response_to_stdout = false
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This PR updates the gemspec to:
* Allow `excon` 1.x
* Update `excon` minimum to 0.97, which appears to have already been required anyway
* Require `base64` to silence the deprecation warning on Ruby 3.3

Local tests have been flaky and the swarm tests don't seem to run with my dockerd at all. However, apart from the swarm tests, I was able to get everything else to pass once. That _might_ require updates to some of the GitHub URLs. I've excluded those updates from this PR as I'm not sure if they are really required or not. I'm happy to add them to the PR if that'd be helpful.